### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/fmadrid1317/e2cbd7df-4741-4a94-896a-d3d4dbdcc7af/5b5df462-140e-4e12-b2c7-c5535e299b16/_apis/work/boardbadge/ab5f336f-0c0a-4484-99ad-8f62181c3356)](https://dev.azure.com/fmadrid1317/e2cbd7df-4741-4a94-896a-d3d4dbdcc7af/_boards/board/t/5b5df462-140e-4e12-b2c7-c5535e299b16/Microsoft.RequirementCategory)
 # Project-JSM-02C
 A Discord Bot inspired by a bot created by a friend. It's main goal is to be educational and hopefully achieve greater things as it goes on. Its name is inspired by Cherry from Saber Marionette Anime Series whose codename was JSM-02C.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/fmadrid1317/e2cbd7df-4741-4a94-896a-d3d4dbdcc7af/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.